### PR TITLE
Use gen_udp.send/4 instead of hardcoding OTP wire format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Fluxter is an InfluxDB writer for Elixir. It uses InfluxDB's line protocol over UDP.
 
+**Important:** this is a forked version with a fix for an error with Fluxter and ERTS >= 10.5.3. Originally, Fluxter would include a hardcoded binary header to each write. This header contains the binary represetation of the destination IP address, port, and optionally a prefix. The write itself was being issued as a plain `send` to the port that was failing with error `einval`. We believe that there was a change in the way ERTS expects this header to be formatted. We patched Fluxter to use `:gen_udp.send/4` and drop the binary header to fix the issue.
+
 **Note:** if you're using Erlang 19 or greater, you need Fluxter 0.4.0 or greater otherwise metrics reporting will (silently) not work because of network driver changes happened between Erlang 18 and Erlang 19.
 
 ## Installation

--- a/lib/fluxter.ex
+++ b/lib/fluxter.ex
@@ -306,8 +306,7 @@ defmodule Fluxter do
         import Supervisor.Spec
 
         {host, port, prefix} = Fluxter.load_config(__MODULE__, options)
-        conn = Fluxter.Conn.new(host, port)
-        conn = %{conn | header: [conn.header | prefix]}
+        conn = Fluxter.Conn.new(host, port, prefix)
 
         Enum.map(@worker_names, &worker(Fluxter.Conn, [conn, &1], id: &1))
         |> Supervisor.start_link(strategy: :one_for_one)

--- a/lib/fluxter/conn.ex
+++ b/lib/fluxter/conn.ex
@@ -7,15 +7,15 @@ defmodule Fluxter.Conn do
 
   require Logger
 
-  defstruct [:sock, :addr, :port]
+  defstruct [:sock, :addr, :port, :prefix]
 
-  def new(host, port) when is_binary(host) do
-    new(string_to_charlist(host), port)
+  def new(host, port, prefix) when is_binary(host) do
+    new(string_to_charlist(host), port, prefix)
   end
 
-  def new(host, port) when is_list(host) or is_tuple(host) do
+  def new(host, port, prefix) when is_list(host) or is_tuple(host) do
     {:ok, addr} = :inet.getaddr(host, :inet)
-    %__MODULE__{addr: addr, port: port}
+    %__MODULE__{addr: addr, port: port, prefix: prefix}
   end
 
   def start_link(%__MODULE__{} = conn, worker) do
@@ -38,7 +38,7 @@ defmodule Fluxter.Conn do
   end
 
   def handle_cast({:write, name, tags, fields}, conn) do
-    packet = Packet.build(name, tags, fields)
+    packet = Packet.build(conn.prefix, name, tags, fields)
     :gen_udp.send(conn.sock, conn.addr, conn.port, packet)
     {:noreply, conn}
   end

--- a/lib/fluxter/packet.ex
+++ b/lib/fluxter/packet.ex
@@ -1,12 +1,10 @@
 defmodule Fluxter.Packet do
   @moduledoc false
 
-  use Bitwise
-
-  def build(name, tags, fields) do
+  def build(prefix, name, tags, fields) do
     tags   = encode_tags(tags)
     fields = encode_fields(fields)
-    [encode_key(name), tags, ?\s, fields]
+    [prefix, encode_key(name), tags, ?\s, fields]
   end
 
   defp encode_tags([]), do: ""

--- a/lib/fluxter/packet.ex
+++ b/lib/fluxter/packet.ex
@@ -3,24 +3,10 @@ defmodule Fluxter.Packet do
 
   use Bitwise
 
-  otp_release = :erlang.system_info(:otp_release)
-  @addr_family if(otp_release >= '19', do: [1], else: [])
-
-  def header({n1, n2, n3, n4}, port) do
-    @addr_family ++ [
-      band(bsr(port, 8), 0xFF),
-      band(port, 0xFF),
-      band(n1, 0xFF),
-      band(n2, 0xFF),
-      band(n3, 0xFF),
-      band(n4, 0xFF)
-    ]
-  end
-
-  def build(header, name, tags, fields) do
+  def build(name, tags, fields) do
     tags   = encode_tags(tags)
     fields = encode_fields(fields)
-    [header, encode_key(name), tags, ?\s, fields]
+    [encode_key(name), tags, ?\s, fields]
   end
 
   defp encode_tags([]), do: ""


### PR DESCRIPTION
This PR fixes a bug with recent versions of OTP that expect the UDP packet header in a different format than the one generated by the original Fluxter implementation